### PR TITLE
♻ Refactor: Clubes, Faqs, Materias, Maestros interfaces

### DIFF
--- a/src/app/interfaces/Clubes.ts
+++ b/src/app/interfaces/Clubes.ts
@@ -29,7 +29,7 @@ export interface Club {
 export interface Logo {
     id:        string;
     filename:  string;
-    mimeType:  MIMEType;
+    mimeType:  string;
     filesize:  number;
     width:     number;
     height:    number;
@@ -37,11 +37,6 @@ export interface Logo {
     createdAt: Date;
     updatedAt: Date;
     url:       string;
-}
-
-export enum MIMEType {
-    ImageJPEG = "image/jpeg",
-    ImagePNG = "image/png",
 }
 
 export interface Sizes {
@@ -53,7 +48,7 @@ export interface Sizes {
 export interface Card {
     width:    number | null;
     height:   number | null;
-    mimeType: MIMEType | null;
+    mimeType: null | string;
     filesize: number | null;
     filename: null | string;
     url?:     string;
@@ -61,14 +56,25 @@ export interface Card {
 
 export interface Proyecto {
     nombre_proyecto:      string;
-    descripcion_proyecto: string;
-    imagen_proyecto:      ImagenProyecto[];
+    descripcion_proyecto: Descripcion[];
     id:                   string;
 }
 
-export interface ImagenProyecto {
-    imagen_proyecto: Logo;
-    id:              string;
+export interface Descripcion {
+    children:    DescripcionProyectoChild[];
+    type?:       string;
+    relationTo?: string;
+    value?:      Logo;
+}
+
+export interface DescripcionProyectoChild {
+    text?:     string;
+    children?: ChildChild[];
+    type?:     string;
+}
+
+export interface ChildChild {
+    text: string;
 }
 
 export interface RedesSociale {
@@ -79,12 +85,6 @@ export interface RedesSociale {
 
 export interface Servicio {
     nombre_servicio:      string;
-    descripcion_servicio: string;
-    imagen_servicio:      ImagenServicio[];
+    descripcion_servicio: Descripcion[];
     id:                   string;
-}
-
-export interface ImagenServicio {
-    imagen_servicio: Logo;
-    id:              string;
 }

--- a/src/app/interfaces/Faqs.ts
+++ b/src/app/interfaces/Faqs.ts
@@ -14,8 +14,64 @@ export interface Faqs {
 export interface FAQ {
     id:        string;
     pregunta:  string;
-    respuesta: string;
-    categoria: string;
+    respuesta: Respuesta[];
+    categoria: Categoria[];
     createdAt: Date;
     updatedAt: Date;
+}
+
+export interface Categoria {
+    id:          string;
+    tag:         string;
+    descripcion: string;
+    createdAt:   Date;
+    updatedAt:   Date;
+}
+
+export interface Respuesta {
+    children:    RespuestaChild[];
+    relationTo?: string;
+    type?:       string;
+    value?:      Value;
+}
+
+export interface RespuestaChild {
+    text?:     string;
+    children?: ChildChild[];
+    linkType?: string;
+    newTab?:   boolean;
+    type?:     string;
+    url?:      string;
+}
+
+export interface ChildChild {
+    text: string;
+}
+
+export interface Value {
+    id:        string;
+    filename:  string;
+    mimeType:  string;
+    filesize:  number;
+    width:     number;
+    height:    number;
+    sizes:     Sizes;
+    createdAt: Date;
+    updatedAt: Date;
+    url:       string;
+}
+
+export interface Sizes {
+    thumbnail: Card;
+    card:      Card;
+    tablet:    Card;
+}
+
+export interface Card {
+    width:    number | null;
+    height:   number | null;
+    mimeType: null | string;
+    filesize: number | null;
+    filename: null | string;
+    url?:     string;
 }

--- a/src/app/interfaces/Maestros.ts
+++ b/src/app/interfaces/Maestros.ts
@@ -1,4 +1,4 @@
-export interface Maestros {
+export interface Faqs {
     Maestro:       Maestro[];
     totalDocs:     number;
     limit:         number;
@@ -16,15 +16,15 @@ export interface Maestro {
     nombre:              string;
     foto:                Foto;
     descripcion:         string;
+    tipo:                string;
     contacto:            Contacto[];
+    redes_sociales:      RedesSociale[];
     formacion_academica: FormacionAcademica[];
     experiencia_laboral: ExperienciaLaboral[];
     proyectos:           Proyecto[];
     investigaciones:     Investigacione[];
     createdAt:           Date;
     updatedAt:           Date;
-    redes_sociales:      any[];
-    tipo:                string;
 }
 
 export interface Contacto {
@@ -36,6 +36,8 @@ export interface Contacto {
 export interface ExperienciaLaboral {
     nombre_empresa:  string;
     descripcion_exp: string;
+    fecha_inicio:    Date;
+    fecha_fin:       Date;
     id:              string;
 }
 
@@ -76,14 +78,35 @@ export interface Card {
 
 export interface Investigacione {
     nombre_inv:      string;
-    descripcion_inv: string;
+    descripcion_inv: Descripcion[];
     id:              string;
-    imagen_inv?:     Foto;
+}
+
+export interface Descripcion {
+    children:    DescripcionInvChild[];
+    type?:       string;
+    relationTo?: string;
+    value?:      Foto;
+}
+
+export interface DescripcionInvChild {
+    text?:     string;
+    children?: ChildChild[];
+    type?:     string;
+}
+
+export interface ChildChild {
+    text: string;
 }
 
 export interface Proyecto {
     nombre_proyecto:      string;
-    descripcion_proyecto: string;
+    descripcion_proyecto: Descripcion[];
     id:                   string;
-    imagen_proyecto?:     Foto;
+}
+
+export interface RedesSociale {
+    nombre_red: string;
+    link_red:   string;
+    id:         string;
 }

--- a/src/app/interfaces/Materias.ts
+++ b/src/app/interfaces/Materias.ts
@@ -16,10 +16,57 @@ export interface Materia {
     nombre:       string;
     descripcion:  string;
     creditos:     number;
+    eje:          string;
     horas:        number;
-    requisitos:   string;
+    requisitos:   Requisito[];
+    seriada:      boolean;
     semestre:     string;
     link_temario: string;
     createdAt:    Date;
     updatedAt:    Date;
+}
+
+export interface Requisito {
+    children:    RequisitoChild[];
+    type?:       string;
+    relationTo?: string;
+    value?:      Value;
+}
+
+export interface RequisitoChild {
+    text?:     string;
+    children?: ChildChild[];
+    type?:     string;
+}
+
+export interface ChildChild {
+    text: string;
+}
+
+export interface Value {
+    id:        string;
+    filename:  string;
+    mimeType:  string;
+    filesize:  number;
+    width:     number;
+    height:    number;
+    sizes:     Sizes;
+    createdAt: Date;
+    updatedAt: Date;
+    url:       string;
+}
+
+export interface Sizes {
+    thumbnail: Card;
+    card:      Card;
+    tablet:    Card;
+}
+
+export interface Card {
+    width:    number | null;
+    height:   number | null;
+    mimeType: null | string;
+    filesize: number | null;
+    filename: null | string;
+    url?:     string;
 }

--- a/src/app/pages/faq/faq.component.ts
+++ b/src/app/pages/faq/faq.component.ts
@@ -22,7 +22,7 @@ export class FaqComponent implements OnInit {
       (res: any) => {
         this.faqs = res.docs;
         this.faqs.forEach((faq: FAQ) => {
-          faq.respuesta = faq.respuesta.replace(/­/g, '<br>');
+          //faq.respuesta = faq.respuesta.replace(/­/g, '<br>');
           return faq;
         });
         console.log(this.faqs)

--- a/src/app/shared/richtext-display/richtext-display.component.html
+++ b/src/app/shared/richtext-display/richtext-display.component.html
@@ -1,4 +1,3 @@
-
 <ng-container *ngFor="let node of content">
     <ng-container *ngIf="isTextNode(node); else blockNode">
         <span [innerHTML]="getSafeHtml(node.text)"
@@ -19,7 +18,8 @@
             <ul class="max-w-md space-y-1  list-disc list-inside" *ngSwitchCase="'ul'"><app-richtext-display [content]="node.children"></app-richtext-display></ul>
             <ol class="max-w-md space-y-1  list-decimal list-inside" *ngSwitchCase="'ol'"><app-richtext-display [content]="node.children"></app-richtext-display></ol>
             <li *ngSwitchCase="'li'"><app-richtext-display [content]="node.children"></app-richtext-display></li>
-            <img *ngSwitchCase="'upload'" [src]="apiUrl + node.value.sizes.thumbnail.url" alt="">
+            <img *ngSwitchCase="'upload'" [src]="apiUrl + node.value.sizes.tablet.url" alt="">
+            <a class="underline underline-offset-4 text-unison-blue-light mt-2 font-semibold italic" *ngSwitchCase="'link'" [href]="node.url" target="_blank" rel="noopener noreferrer"><app-richtext-display [content]="node.children"></app-richtext-display></a>
             <p *ngSwitchDefault><app-richtext-display [content]="node.children"></app-richtext-display></p>
         </ng-container>
     </ng-template>


### PR DESCRIPTION
# Changes description
Add rich text support on the Clubes, Faqs, Materias and Maestros interfaces.
a tag support for the rich text map.

# Task's URL
[Corrección de endpoints richtext](https://www.notion.so/Correcci-n-de-endpoints-richtext-f7e7de4934514ce687bb10eac7837590?pvs=4)

# What was done in this pull request
- Richtext support Clubes Interface
- Richtext support Faqs Interface
- Richtext support Materias Interface
- Richtext support Maestros Interface
- a tag support map richtext
