### PR TITLE
🔧 Fix:Add animation of carousel

### DIFF
--- a/src/app/components/carousel/carousel.component.html
+++ b/src/app/components/carousel/carousel.component.html
@@ -1,4 +1,4 @@
-<div class="transition-transform duration-500 ease-in-out">
+<div>
     <div
         class="bg-unison-blue h-80 mt-4 rounded-2xl overflow-hidden relative max-w-screen-tablet mx-auto aspect-w-16 aspect-h-9">
         <div class="relative ">
@@ -7,7 +7,7 @@
                     <li class="carousel-slide w-full md:w-1/2 lg:w-1/3 xl:w-1/4"
                         *ngFor="let slide of slides; let i = index"
                         [ngStyle]="{ 'transform': i === currentSlideIndex ? 'translateX(0)' : 'translate-x-full'}">
-                        <img class="w-full h-80 object-cover md:h-auto lg:h-auto xl:h-auto" [src]="slide.imageUrl"
+                        <img class="w-full h-80 object-cover md:h-auto lg:h-auto xl:h-auto animate-fade-right animate-once animate-duration-[2500ms]" [src]="slide.imageUrl"
                             alt="">
                         <div class="absolute bottom-0 left-0 w-full px-2 py-1 bg-unison-yellow-dark/70">
                             <p class="text-sm md:text-base lg:text-lg xl:text-xl leading-tight">{{ slide.text }}</p>

--- a/src/app/components/carousel/carousel.component.ts
+++ b/src/app/components/carousel/carousel.component.ts
@@ -48,6 +48,19 @@ export class CarouselComponent implements AfterViewInit {
     this.currentSlideIndex = nextIndex;
     this.updateIndicators();
     this.showCurrentSlide();
+
+    // Remover la clase de animación de la imagen actual
+    const currentSlide = document.querySelector('.carousel-slide:not(.hidden) img');
+    if (currentSlide) {
+      currentSlide.classList.remove('animate-fade-right');
+      currentSlide.classList.remove('animate-fade-left');
+    }
+
+    // Agregar la clase de animación a la siguiente imagen
+    const nextSlide = document.querySelector(`.carousel-slide:nth-child(${nextIndex + 1}) img`);
+    if (nextSlide) {
+      nextSlide.classList.add('animate-fade-right');
+    }
   }
 
   prevSlide() {
@@ -57,6 +70,19 @@ export class CarouselComponent implements AfterViewInit {
     //this.currentSlideIndex = (this.currentSlideIndex - 1 + this.slides.length) % this.slides.length;
     this.updateIndicators();
     this.showCurrentSlide();
+
+    // Remover la clase de animación de la imagen actual
+    const currentSlide = document.querySelector('.carousel-slide:not(.hidden) img');
+    if (currentSlide) {
+      currentSlide.classList.remove('animate-fade-right');
+      currentSlide.classList.remove('animate-fade-left');
+    }
+
+    // Agregar la clase de animación a la siguiente imagen
+    const prevSlide = document.querySelector(`.carousel-slide:nth-child(${prevIndex + 1}) img`);
+    if (prevSlide) {
+      prevSlide.classList.add('animate-fade-left');
+    }
   }
 
   goToSlide(index: number) {
@@ -87,22 +113,6 @@ export class CarouselComponent implements AfterViewInit {
       }
     });
   }
-
-  // showCurrentSlide2() {
-  //   const slides = document.querySelectorAll('.carousel-slide') as NodeListOf<HTMLElement>;
-  
-  //   slides.forEach((slide: HTMLElement, index: number) => {
-  //     if (index === this.currentSlideIndex) {
-  //       slide.style.transform = 'translateX(0%)'; // Slide actual visible
-  //     } else {
-  //       const distance = (index - this.currentSlideIndex) * 100; // Distancia para deslizar
-  //       slide.style.transform = `translateX(${distance}%)`; // Aplicar deslizamiento
-  //     }
-  //   });
-  // }
-  
-
-
   private secondsRemaining = 8; // El intervalo se establece en 8 segundos  
   private manualInteraction = false;
   autoNextSlide() {

--- a/src/app/pages/faq/faq.component.html
+++ b/src/app/pages/faq/faq.component.html
@@ -28,6 +28,7 @@
                     <div class="max-h-0 overflow-hidden peer-checked:max-h-full ml-4 mt-3">
                         <app-richtext-display [content]="faq.respuesta"></app-richtext-display>
                     </div>
+                    
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Changes description
The animation was added when switching news in the carousel.

# Task's URL
- [carousel](https://www.notion.so/Corregir-carrusel-de-noticias-6be34fe7e1f34e7c85e9fdeefbc91558?pvs=4)

# What was done in this pull request
- The animation was added to the carousel using the Tailwind animation library.

# Demo / Screenshot / Video
https://github.com/andresmc98/isi-portal/assets/79737436/1dc5a7d7-7055-4fb5-be66-94480b64a4de

